### PR TITLE
Apollo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ module.exports = {
   `,
   resolvers: {
     hello: () => `hello world`
-  },
+  }
   // any other apollo-server config
 }
 ```
@@ -27,10 +27,15 @@ where `typeDefs` is a string that decscribes your schema, then create a `now.jso
   "version": 2,
   "builds": [
     { "src": "index.js", "use": "now-graphql" }
+  ],
+  "routes": [
+    { "src": "/graphql", "dest": "index.js" }
   ]
 }
 ```
 
 then run `now` to deploy with [now](https://now.sh/).
 
-Since you can use any [apollo-server](https://github.com/apollographql/apollo-server) config, feel free to use `schema` or anything else you might do with that.
+Since you can use any [apollo-server](https://www.apollographql.com/docs/apollo-server/api/apollo-server.html) config, feel free to use `schema` or anything else you might do with that.
+
+The default path is `/graphql`, but you can change that by adding `path` to your server, and updating your route in `now.json` to point to it.

--- a/README.md
+++ b/README.md
@@ -8,18 +8,21 @@ create an `index.js` file
 
 ```js
 module.exports = {
-  schema: `
+  typeDefs: `
     type Query {
       hello: String
     }
   `,
   resolvers: {
     hello: () => `hello world`
+  },
+  config: {
+    // any other apollo-server config
   }
 }
 ```
 
-where `schema` is a string or a GraphQLSchema object, then create a `now.json` file
+where `typeDefs` is a string or a GraphQLSchema object, then create a `now.json` file
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -16,13 +16,11 @@ module.exports = {
   resolvers: {
     hello: () => `hello world`
   },
-  config: {
-    // any other apollo-server config
-  }
+  // any other apollo-server config
 }
 ```
 
-where `typeDefs` is a string or a GraphQLSchema object, then create a `now.json` file
+where `typeDefs` is a string that decscribes your schema, then create a `now.json` file
 
 ```json
 {
@@ -34,3 +32,5 @@ where `typeDefs` is a string or a GraphQLSchema object, then create a `now.json`
 ```
 
 then run `now` to deploy with [now](https://now.sh/).
+
+Since you can use any [apollo-server](https://github.com/apollographql/apollo-server) config, feel free to use `schema` or anything else you might do with that.

--- a/example/index.js
+++ b/example/index.js
@@ -6,9 +6,12 @@ module.exports = {
   `,
 
   resolvers: {
-    hello: () => `hello world`
+    Query: {
+      hello: () => `hello world`
+    }
   },
 
   introspection: true,
-  playground: { settings: { 'request.credentials': 'same-origin' } }
+  playground: true,
+  path: '/'
 }

--- a/example/index.js
+++ b/example/index.js
@@ -1,10 +1,16 @@
 module.exports = {
-  schema: `
+  typeDefs: `
     type Query {
       hello: String
     }
   `,
+
   resolvers: {
     hello: () => `hello world`
+  },
+
+  config: {
+    introspection: true,
+    playground: { settings: { 'request.credentials': 'same-origin' } }
   }
 }

--- a/example/index.js
+++ b/example/index.js
@@ -9,8 +9,6 @@ module.exports = {
     hello: () => `hello world`
   },
 
-  config: {
-    introspection: true,
-    playground: { settings: { 'request.credentials': 'same-origin' } }
-  }
+  introspection: true,
+  playground: { settings: { 'request.credentials': 'same-origin' } }
 }

--- a/example/now.json
+++ b/example/now.json
@@ -2,5 +2,8 @@
   "version": 2,
   "builds": [
     { "src": "index.js", "use": "now-graphql" }
+  ],
+  "routes": [
+    { "src": "/graphql", "dest": "index.js" }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -9,14 +9,14 @@ module.exports = {
     console.log(`adding graphql dependencies to package.json`)
     const pkg = files['package.json'] ? JSON.parse(files['package.json'].data.toString()) : { dependencies: {} }
     const json = JSON.parse(await fs.readFile(path.join(__dirname, 'server/package.json'), 'utf8'))
-    Object.keys(json.dependencies).forEach(dep => pkg.dependencies[dep] = json.dependencies[dep])
+    Object.keys(json.dependencies).forEach(dep => { pkg.dependencies[dep] = json.dependencies[dep] })
     files['package.json'] = new FileBlob({ data: JSON.stringify(pkg) })
 
     console.log(`setting graphql entrypoint`)
     files['_entrypoint.js'] = files[entrypoint]
     files[entrypoint] = new FileFsRef({ fsPath: path.join(__dirname, 'server/index.js') })
 
-    return await build({ entrypoint, files, workPath })
+    return build({ entrypoint, files, workPath })
   },
   prepareCache,
   config

--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,16 @@
-const graphqlHTTP = require('express-graphql')
-const { buildSchema } = require('graphql')
-let { schema, resolvers, graphiql=true } = require('./_entrypoint')
+const express = require('express')
+const { ApolloServer } = require('apollo-server-express')
 
-const rootValue = resolvers
-if (typeof schema === 'string') {
-  schema = buildSchema(schema)
-}
+let { typeDefs, resolvers, schemaDirectives, config } = require('./_entrypoint')
 
-module.exports = graphqlHTTP({ schema, rootValue, graphiql })
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  schemaDirectives,
+  ...config
+})
+
+const app = express()
+server.applyMiddleware({ app })
+
+module.exports = app

--- a/server/index.js
+++ b/server/index.js
@@ -1,14 +1,9 @@
 const express = require('express')
 const { ApolloServer } = require('apollo-server-express')
 
-let { typeDefs, resolvers, schemaDirectives, config } = require('./_entrypoint')
+let config = require('./_entrypoint')
 
-const server = new ApolloServer({
-  typeDefs,
-  resolvers,
-  schemaDirectives,
-  ...config
-})
+const server = new ApolloServer(config)
 
 const app = express()
 server.applyMiddleware({ app })

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "express-graphql": "^0.7.1",
-    "graphql": "^14.1.1"
+    "apollo-server-express": "latest",
+    "express": "latest"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "apollo-server-express": "latest",
-    "express": "latest"
+    "express": "latest",
+    "graphql": "latest"
   }
 }


### PR DESCRIPTION
This is the start of using apollo-server.

I'm not sure how to test without publishing on npm, but I think it will work ok with the example.

I take a slightly different approach, in that you can use `typeDefs` for a string, or build your own `schema` your way (because apollo supports this, directly.)

Next step is to include files in example dir (ignoring .nowignore referenced files) so we can do dynamic merged schema and stuff like that (to help with #1 )